### PR TITLE
Don't use the cache when retrying generate() for the judge

### DIFF
--- a/src/scoring.py
+++ b/src/scoring.py
@@ -117,7 +117,7 @@ First, write out in a step by step manner your reasoning about the criterion to 
                 try:
                     result = await model.generate(
                         prompt,
-                        cache=CachePolicy(expiry=None),
+                        cache=CachePolicy(expiry=None) if current_retry == 0 else None,
                         config=GenerateConfig(
                             **batch_args,
                         ),


### PR DESCRIPTION
Currently the judge retries seem to use generate() with the cache which isn't very helpful. This PR makes generate() not use the cache when retrying the judge query. In my testing, this greatly reduced how often the code is unable to generate a response from the judge because max_retries is exceeded.