### PR TITLE
change devcontainer name to be user specific

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -51,6 +51,7 @@ RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     bash \
  && apt-get update # install script clears apt list cache \
  && groupmod -g ${DOCKER_GID} docker
+VOLUME /var/lib/docker
 
 COPY --from=uv /uv /uvx /usr/local/bin/
 
@@ -70,8 +71,10 @@ RUN groupadd -g ${GROUP_ID} ${APP_USER} \
     -s /bin/bash \
  && mkdir -p ${APP_DIR} /home/${APP_USER}/.cache/inspect_ai \
  && chown -R ${USER_ID}:${GROUP_ID} ${APP_DIR} /home/${APP_USER}
+VOLUME /home/${APP_USER}
 
 COPY --from=builder --chown=${USER_ID}:${GROUP_ID} ${UV_PROJECT_ENVIRONMENT} ${UV_PROJECT_ENVIRONMENT}
 WORKDIR ${APP_DIR}
+
 ENTRYPOINT ["/usr/local/share/docker-init.sh"]
 CMD ["sleep", "infinity"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,6 @@
     }
   ],
   "runArgs": [
-    "--name=cot-faithfulness-dev-${localEnv:USER}${localEnv:USERNAME}",
     "--hostname=cot-faithfulness",
     "--dns-search=koi-moth.ts.net",
     "--privileged"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,7 @@
     }
   ],
   "runArgs": [
-    "--name=cot-faithfulness-dev",
+    "--name=cot-faithfulness-dev-${localEnv:USER}${localEnv:USERNAME}",
     "--hostname=cot-faithfulness",
     "--dns-search=koi-moth.ts.net",
     "--privileged"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,16 +8,6 @@
   "workspaceFolder": "/home/metr/app",
   "mounts": [
     {
-      "source": "cot-faithfulness-home",
-      "target": "/home/metr",
-      "type": "volume"
-    },
-    {
-      "source": "cot-faithfulness-docker-data",
-      "target": "/var/lib/docker",
-      "type": "volume"
-    },
-    {
       "source": "${localEnv:HOME}${localEnv:USERPROFILE}/.cache/inspect_ai",
       "target": "/home/metr/.cache/inspect_ai",
       "type": "bind"


### PR DESCRIPTION
It seems like when thomas and I both tried to connect to the dev container in the vm, we were kicking each other out.
The existing change in this PR didn't fix it since the usernames for both of us are `ec2-user`. Sami told me to remove the --name arg, but I haven't tested whether this works